### PR TITLE
Fix 1.19 Block palette version

### DIFF
--- a/src/main/java/com/nukkitx/blockstateupdater/BlockStateUpdater_1_19_0.java
+++ b/src/main/java/com/nukkitx/blockstateupdater/BlockStateUpdater_1_19_0.java
@@ -22,13 +22,13 @@ public class BlockStateUpdater_1_19_0 implements BlockStateUpdater {
     }
 
     private void renameIdentifier(CompoundTagUpdaterContext context, String from, String to) {
-        context.addUpdater(1, 19, 0, true) // Here we go again Mojang
+        context.addUpdater(1, 18, 10, true) // Here we go again Mojang
                 .match("name", from)
                 .edit("name", helper -> helper.replaceWith("name", to));
     }
 
     private void addProperty(CompoundTagUpdaterContext context, String identifier, String propertyName, Object value) {
-        context.addUpdater(1, 19, 0, true) // Here we go again Mojang
+        context.addUpdater(1, 18, 10, true) // Here we go again Mojang
                 .match("name", identifier)
                 .visit("states")
                 .tryAdd(propertyName, value);


### PR DESCRIPTION
The bedrock block palette version for 1.19.0 is still 1.18.10 (17959425)