### PR TITLE
Fix 1.20.30 directions

### DIFF
--- a/src/main/java/org/cloudburstmc/blockstateupdater/BlockStateUpdater_1_20_30.java
+++ b/src/main/java/org/cloudburstmc/blockstateupdater/BlockStateUpdater_1_20_30.java
@@ -1,5 +1,6 @@
 package org.cloudburstmc.blockstateupdater;
 
+import org.cloudburstmc.blockstateupdater.util.OrderedUpdater;
 import org.cloudburstmc.blockstateupdater.util.tagupdater.CompoundTagUpdaterContext;
 
 public class BlockStateUpdater_1_20_30 implements BlockStateUpdater {
@@ -25,54 +26,59 @@ public class BlockStateUpdater_1_20_30 implements BlockStateUpdater {
             "silver"
     };
 
-    public static final String[] DIRECTIONS = {
-            "east",
-            "south",
-            "north",
-            "west",
-            "up",
-            "down"
-    };
+    public static final OrderedUpdater FACING_TO_BLOCK = new OrderedUpdater(
+        "facing_direction", "minecraft:block_face",
+        "down", "up", "north", "south", "west", "east");
+
+    public static final OrderedUpdater FACING_TO_CARDINAL = new OrderedUpdater(
+        "facing_direction", "minecraft:cardinal_direction", 2,
+        "north", "south", "west", "east");
+
+    public static final OrderedUpdater DIRECTION_TO_CARDINAL = new OrderedUpdater(
+        "direction", "minecraft:cardinal_direction",
+        "south", "west", "north", "east");
 
     @Override
     public void registerUpdaters(CompoundTagUpdaterContext ctx) {
         for (String color : COLORS) {
             if (color.equals("silver")) {
-                this.addTypeUpdater(ctx, "minecraft:stained_glass", "color", color, "minecraft:light_gray_stained_glass");
-                this.addTypeUpdater(ctx, "minecraft:stained_glass_pane", "color", color, "minecraft:light_gray_stained_glass_pane");
-                this.addTypeUpdater(ctx, "minecraft:concrete_powder", "color", color, "minecraft:light_gray_concrete_powder");
-                this.addTypeUpdater(ctx, "minecraft:stained_hardened_clay", "color", color, "minecraft:light_gray_terracotta");
+                this.addColorUpdater(ctx, "minecraft:stained_glass", color, "minecraft:light_gray_stained_glass");
+                this.addColorUpdater(ctx, "minecraft:stained_glass_pane", color, "minecraft:light_gray_stained_glass_pane");
+                this.addColorUpdater(ctx, "minecraft:concrete_powder", color, "minecraft:light_gray_concrete_powder");
+                this.addColorUpdater(ctx, "minecraft:stained_hardened_clay", color, "minecraft:light_gray_terracotta");
             } else {
-                this.addTypeUpdater(ctx, "minecraft:stained_glass", "color", color, "minecraft:" + color + "_stained_glass");
-                this.addTypeUpdater(ctx, "minecraft:stained_glass_pane", "color", color, "minecraft:" + color + "_stained_glass_pane");
-                this.addTypeUpdater(ctx, "minecraft:concrete_powder", "color", color, "minecraft:" + color + "_concrete_powder");
-                this.addTypeUpdater(ctx, "minecraft:stained_hardened_clay", "color", color, "minecraft:" + color + "_terracotta");
+                this.addColorUpdater(ctx, "minecraft:stained_glass", color, "minecraft:" + color + "_stained_glass");
+                this.addColorUpdater(ctx, "minecraft:stained_glass_pane", color, "minecraft:" + color + "_stained_glass_pane");
+                this.addColorUpdater(ctx, "minecraft:concrete_powder", color, "minecraft:" + color + "_concrete_powder");
+                this.addColorUpdater(ctx, "minecraft:stained_hardened_clay", color, "minecraft:" + color + "_terracotta");
             }
         }
 
-        this.addDirectionUpdater(ctx, "minecraft:amethyst_cluster", "facing_direction", "minecraft:block_face");
-        this.addDirectionUpdater(ctx, "minecraft:anvil", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:big_dripleaf", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:blast_furnace", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:calibrated_sculk_sensor", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:campfire", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:end_portal_frame", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:furnace", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:large_amethyst_bud", "facing_direction", "minecraft:block_face");
-        this.addDirectionUpdater(ctx, "minecraft:lectern", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:lit_blast_furnace", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:lit_furnace", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:lit_smoker", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:medium_amethyst_bud", "facing_direction", "minecraft:block_face");
-        this.addDirectionUpdater(ctx, "minecraft:pink_petals", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:powered_comparator", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:powered_repeater", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:small_amethyst_bud", "facing_direction", "minecraft:block_face");
-        this.addDirectionUpdater(ctx, "minecraft:small_dripleaf_block", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:smoker", "facing_direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:soul_campfire", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:unpowered_comparator", "direction", "minecraft:cardinal_direction", 3);
-        this.addDirectionUpdater(ctx, "minecraft:unpowered_repeater", "direction", "minecraft:cardinal_direction", 3);
+        this.addDirectionUpdater(ctx, "minecraft:amethyst_cluster", FACING_TO_BLOCK);
+        this.addDirectionUpdater(ctx, "minecraft:medium_amethyst_bud", FACING_TO_BLOCK);
+        this.addDirectionUpdater(ctx, "minecraft:large_amethyst_bud", FACING_TO_BLOCK);
+        this.addDirectionUpdater(ctx, "minecraft:small_amethyst_bud", FACING_TO_BLOCK);
+
+        this.addDirectionUpdater(ctx, "minecraft:blast_furnace", FACING_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:furnace", FACING_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:lit_blast_furnace", FACING_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:lit_furnace", FACING_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:lit_smoker", FACING_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:smoker", FACING_TO_CARDINAL);
+
+        this.addDirectionUpdater(ctx, "minecraft:anvil", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:big_dripleaf", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:calibrated_sculk_sensor", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:campfire", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:end_portal_frame", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:lectern", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:pink_petals", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:powered_comparator", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:powered_repeater", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:small_dripleaf_block", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:soul_campfire", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:unpowered_comparator", DIRECTION_TO_CARDINAL);
+        this.addDirectionUpdater(ctx, "minecraft:unpowered_repeater", DIRECTION_TO_CARDINAL);
 
         ctx.addUpdater(1, 20, 30)
                 .regex("name", "minecraft:.+slab(?:[2-4])?\\b")
@@ -95,46 +101,22 @@ public class BlockStateUpdater_1_20_30 implements BlockStateUpdater {
         // TODO: Mojang added 51 updaters, I managed to do the same with less. Maybe I missed something? Need to check later.
     }
 
-    private void addTypeUpdater(CompoundTagUpdaterContext context, String identifier, String typeState, String type, String newIdentifier) {
+    private void addColorUpdater(CompoundTagUpdaterContext context, String identifier, String color, String newIdentifier) {
         context.addUpdater(1, 20, 30)
                 .match("name", identifier)
                 .visit("states")
-                .match(typeState, type)
-                .edit(typeState, helper -> helper.getRootTag().put("name", newIdentifier))
-                .remove(typeState);
+                .match("color", color)
+                .edit("color", helper -> helper.getRootTag().put("name", newIdentifier))
+                .remove("color");
     }
 
-    private void addDirectionUpdater(CompoundTagUpdaterContext ctx, String identifier, String oldProperty, String newProperty) {
-        this.addDirectionUpdater(ctx, identifier, oldProperty, newProperty, 5);
-    }
-
-    private void addDirectionUpdater(CompoundTagUpdaterContext ctx, String identifier, String oldProperty, String newProperty, int maxMeta) {
+    private void addDirectionUpdater(CompoundTagUpdaterContext ctx, String identifier, OrderedUpdater updater) {
         ctx.addUpdater(1, 20, 30)
                 .match("name", identifier)
                 .visit("states")
-                .edit(oldProperty, helper -> {
+                .edit(updater.getOldProperty(), helper -> {
                     int value = (int) helper.getTag();
-                    helper.replaceWith(newProperty, DIRECTIONS[value > maxMeta ? 0 : value]);
-                });
-    }
-
-    private void addSlabUpdater(CompoundTagUpdaterContext ctx, String identifier) {
-        ctx.addUpdater(1, 20, 30)
-                .match("name", identifier)
-                .visit("states")
-                .edit("top_slot_bit", helper -> {
-                    boolean value;
-                    if (helper.getTag() instanceof Byte) {
-                        value = (byte) helper.getTag() == 1;
-                    } else {
-                        value = (boolean) helper.getTag();
-                    }
-
-                    if (value) {
-                        helper.replaceWith("minecraft:vertical_half", "top");
-                    } else {
-                        helper.replaceWith("minecraft:vertical_half", "bottom");
-                    }
+                    helper.replaceWith(updater.getNewProperty(), updater.translate(value));
                 });
     }
 }

--- a/src/main/java/org/cloudburstmc/blockstateupdater/util/OrderedUpdater.java
+++ b/src/main/java/org/cloudburstmc/blockstateupdater/util/OrderedUpdater.java
@@ -1,0 +1,51 @@
+package org.cloudburstmc.blockstateupdater.util;
+
+import lombok.Getter;
+
+/**
+ * Stores updates from ints to Strings.
+ */
+public class OrderedUpdater {
+
+    @Getter
+    private final String oldProperty;
+    @Getter
+    private final String newProperty;
+
+    private final String[] order;
+    private final int offset;
+
+    /**
+     * {@link #OrderedUpdater(String, String, int, String...)} with an offset of 0 (old values start at 0)
+     */
+    public OrderedUpdater(String oldProperty, String newProperty, String... order) {
+        this(oldProperty, newProperty, 0, order);
+    }
+
+    /**
+     * Creates an OrderedUpdater whose values are provided by the ordered array.
+     *
+     * @param oldProperty the old state property
+     * @param newProperty the new state property
+     * @param offset the difference between a value's old integer type and the value's index in the array.
+     *               If the first element has an old value of n, then the offset is n.
+     * @param order an array of ordered values
+     */
+    public OrderedUpdater(String oldProperty, String newProperty, int offset, String... order) {
+        if (order.length < 1) {
+            throw new IllegalArgumentException("empty order array");
+        }
+        this.oldProperty = oldProperty;
+        this.newProperty = newProperty;
+        this.offset = offset;
+        this.order = order;
+    }
+
+    public String translate(int value) {
+        int index = value - offset;
+        if (index < 0 || index >= order.length) {
+            index = 0;
+        }
+        return order[index];
+    }
+}


### PR DESCRIPTION
`facing_direction` and `direction` map to different cardinal directions. pretty sure the current DIRECTIONS is out of order anyway.

Not too sure how I feel about these changes. I figured the new OrderedUpdater could likely be used in future update. Not too happy with how the old/new property are stored in it solely for the purpose of storage, but I wanted to avoid a bunch of string literals.

I can refactor the code to resemble moreso what it used to be. `FACING_TO_CARDINAL` and `FACING_TO_BLOCK` would likely be consolidated into one.

Feel free to make any changes